### PR TITLE
Fix import lodash/last bug

### DIFF
--- a/__tests__/fixtures/destructured/input.js
+++ b/__tests__/fixtures/destructured/input.js
@@ -1,4 +1,4 @@
-import { isEmpty, chunk } from 'lodash';
+import { isEmpty, chunk, last } from 'lodash';
 
 const empty = {};
 const notEmpty = {
@@ -9,3 +9,5 @@ isEmpty(obj);
 isEmpty(notEmpty);
 
 chunk(['a', 'b', 'c', 'd'], 2);
+
+last(['a', 'b']);

--- a/__tests__/fixtures/destructured/output.js
+++ b/__tests__/fixtures/destructured/output.js
@@ -1,5 +1,6 @@
 import isEmpty from "lodash/isEmpty";
 import chunk from "lodash/chunk";
+import last from "lodash/last";
 const empty = {};
 const notEmpty = {
   a: 1
@@ -7,3 +8,4 @@ const notEmpty = {
 isEmpty(obj);
 isEmpty(notEmpty);
 chunk(["a", "b", "c", "d"], 2);
+last(["a", "b"]);

--- a/index.js
+++ b/index.js
@@ -47,15 +47,9 @@ function pluginLodashImport(options = {}) {
 
           importName.forEach(name => {
             const previousResult = `${result ? `${result}\n` : ''}`;
-
-            if (name.includes('as')) {
-              const realImportName = name.split(' as ');
-
-              if (realImportName.length !== 2) {
-                return;
-              }
-
-              result = `${previousResult}import ${realImportName[1]} from 'lodash/${realImportName[0]}';`;
+            if (name.includes(' as ')) {
+              const [realName, alias] = name.split(' as ');
+              result = `${previousResult}import ${alias} from 'lodash/${realName}';`;
             } else {
               result = `${previousResult}import ${name} from 'lodash/${name}';`;
             }


### PR DESCRIPTION
There was a problem trying to import `last`

```
import { last } from 'lodash';
```

The problem was the condition for checking if the import was an alias. It was checking `.includes('as')` (which is true for `last`) instead of `.includes(' as ')`