### PR TITLE
feat: handle double quotes lodash imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,7 @@ function pluginLodashImport(options = {}) {
         const extension = path.extname(args.path).replace('.', '');
         const loader = JS_EXTENSIONS.has(extension) ? 'jsx' : extension;
 
-        const ramdaImportRegex =
-          /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
+        const ramdaImportRegex = /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
 
         const lodashImports = contents.match(lodashImportRegex);
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ function pluginLodashImport(options = {}) {
         const extension = path.extname(args.path).replace('.', '');
         const loader = JS_EXTENSIONS.has(extension) ? 'jsx' : extension;
 
-        const lodashImportRegex = /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)(?:(?:'lodash\/?.*?'))[\s]*?(?:;|$|)/g;
+        const ramdaImportRegex =
+          /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
 
         const lodashImports = contents.match(lodashImportRegex);
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function pluginLodashImport(options = {}) {
         const extension = path.extname(args.path).replace('.', '');
         const loader = JS_EXTENSIONS.has(extension) ? 'jsx' : extension;
 
-        const ramdaImportRegex = /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
+        const lodashImportRegex = /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
 
         const lodashImports = contents.match(lodashImportRegex);
 


### PR DESCRIPTION
I've found this solution from https://github.com/mikeduminy/esbuild-plugin-ramda/blob/main/index.js#L18. Thank you @mikeduminy !

```
import { unionWith, reverse, differenceWith } from "lodash";

import { unionWith, reverse, differenceWith } from 'lodash';

```